### PR TITLE
Upgrade Node.js runtime from 20.x to 22.x

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           cache: npm
           cache-dependency-path: ./package.json
-          node-version: 20
+          node-version: 22
 
       - name: 📥 Install deps
         run: npm install
@@ -52,7 +52,7 @@ jobs:
         with:
           cache: npm
           cache-dependency-path: ./package.json
-          node-version: 20
+          node-version: 22
 
       - name: 📥 Install deps
         run: npm install
@@ -73,7 +73,7 @@ jobs:
         with:
           cache: npm
           cache-dependency-path: ./package.json
-          node-version: 20
+          node-version: 22
 
       - name: 👀 Env
         run: |

--- a/app.arc
+++ b/app.arc
@@ -2,7 +2,7 @@
 weather-gear-ad92
 
 @aws
-runtime nodejs20.x
+runtime nodejs22.x
 timeout 15
 # concurrency 1
 # memory 1152

--- a/app/components/AppFrame.tsx
+++ b/app/components/AppFrame.tsx
@@ -39,7 +39,7 @@ export const AppFrame = ({ children, sport }: Props) => {
             <Link to="/manual" className="hover:text-slate-300">Manual Mode</Link>
             <Link to="/about" className="hover:text-slate-300">About</Link>
           </div>
-          <span>App updated 11.30.2024</span>
+          <span>Updated 04.29.2026</span>
         </footer>
       </div>
       {navigation.state !== "idle" && <Loading />}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "vite-tsconfig-paths": "^4.3.1"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Updates AWS Lambda runtime from `nodejs20.x` to `nodejs22.x` in `app.arc`
- Updates all GitHub Actions jobs (lint, typecheck, deploy) from Node 20 to Node 22
- Updates `engines.node` in `package.json` to `>=22.0.0`
- Updates footer date in `AppFrame.tsx` to 04.29.2026

Node.js 20 has reached end-of-life on AWS Lambda. Staged and verified on `dev` before merging to production.

## Test plan
- [x] Deployed to staging via `dev` branch
- [x] Staging verified good

🤖 Generated with [Claude Code](https://claude.com/claude-code)